### PR TITLE
Align chat panel with map height

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   header.appbar nav{display:flex;gap:.5rem;flex-wrap:wrap}
   header.appbar nav button{padding:.45rem .6rem}
 
-  .container{display:grid;grid-template-columns:320px 1fr 360px;gap:1rem;padding:1rem;align-items:start}
+  .container{display:grid;grid-template-columns:320px 1fr 360px;gap:1rem;padding:1rem;align-items:stretch}
   @media (max-width: 1100px){ .container{grid-template-columns:1fr} }
 
   .panel{background:linear-gradient(180deg, var(--panel), var(--panel-2));border:1px solid #1a2130;border-radius:12px;padding:1rem;box-shadow:var(--glow)}
@@ -89,10 +89,11 @@
     color:#cfe1ff;font-size:.75rem}
 
   /* Chat (fixed height + scrollbar) */
-  #chat{display:flex;flex-direction:column}
+  #chat{display:flex;flex-direction:column;height:100%}
   #chatLog{
-    height:340px; /* fixed, scrollable */
+    flex:1; /* fill remaining space */
     overflow-y:auto;
+    min-height:0;
     background:#0c121d;border:1px solid #1a2130;border-radius:8px;padding:.75rem;scroll-behavior:smooth;
   }
   #chatLog .line{display:flex;align-items:flex-start;gap:.6rem;margin:.45rem 0}


### PR DESCRIPTION
## Summary
- Stretch layout grid and chat panel so the Keeper & Chat section reaches the bottom of the map
- Let chat log flex to fill available height for longer visible conversation history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982ee3ee6c8331a6857685cee6b45a