### PR TITLE
Default Keeper trigger to auto

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,8 +309,8 @@
         <label><input type="checkbox" id="keeperOn" checked/> Keeper AI On</label>
         <label>Keeper Trigger</label>
         <select id="keeperTrigger">
-          <option value="manual" selected>Manual (Ask Keeper or /keeper)</option>
-          <option value="auto">Auto (every non-slash message)</option>
+          <option value="manual">Manual (Ask Keeper or /keeper)</option>
+          <option value="auto" selected>Auto (every non-slash message)</option>
         </select>
         <label>Keeper Style</label>
         <select id="keeperStyle">
@@ -562,7 +562,7 @@
 /* =========================================================
    SOLO INVESTIGATOR — Tutorial Solo VTT (client‑only)
    Token‑frugal, with Character Sheets + Inventory, stable chat scroll,
-   asset‑full saves, manual Keeper trigger, stronger variety
+   asset‑full saves, auto Keeper trigger, stronger variety
    ========================================================= */
 
 /* ---------- CONSTANTS ---------- */
@@ -677,7 +677,7 @@ const state = {
     ttsOn:false, ttsQueue:true, ttsProviderDefault:'browser',
     elevenKey:'', voiceId:'',
     rulesPack:'',
-    keeperTrigger:'manual',
+    keeperTrigger:'auto',
     keeperStyle:'normal',
     keeperMax:450,
     voiceMap:{} // { name: {provider:'browser'|'eleven'|'none', id:'VoiceNameOrId'} }
@@ -726,7 +726,7 @@ function loadSettings(){
   byId('ttsQueue').checked = state.settings.ttsQueue;
   byId('ttsProviderDefault').value = state.settings.ttsProviderDefault || 'browser';
   byId('rulesPack').value = state.settings.rulesPack;
-  byId('keeperTrigger').value = state.settings.keeperTrigger || 'manual';
+  byId('keeperTrigger').value = state.settings.keeperTrigger || 'auto';
   byId('keeperStyle').value = state.settings.keeperStyle || 'normal';
   byId('keeperMax').value = state.settings.keeperMax || 450;
 }
@@ -1194,7 +1194,7 @@ function askKeeperFromInput(){
 function sendChat(){ const val=byId('chatInput').value.trim(); if(!val) return; byId('chatInput').value=''; addLine(val,'you');
   if(val.startsWith('/')){ runSlash(val); return; }
   if(!state.settings.keeperOn) return;
-  if((state.settings.keeperTrigger||'manual')==='auto'){ keeperReply(val); }
+  if((state.settings.keeperTrigger||'auto')==='auto'){ keeperReply(val); }
 }
 
 /* ---------- SLASH ---------- */

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ A single-file, client-only tabletop experience inspired by investigative horror 
 - **Tactical Board:** Grid, fog of war (reveal/hide/undo), ruler, pings, tokens w/ portraits, active-turn highlight, movement budgets.
 - **Voices:** Queue-based TTS with **Browser voices (free)** or **ElevenLabs** (premium). Per-speaker voice selection + local caching for replays.
 - **Asset-Full Saves:** Export/import includes scenes, portraits, and handouts as data URLs—no re-generation needed when you reload.
-- **Cost Controls:** Local asset cache, selective Keeper trigger (manual by default), quick command picker, offline placeholders if you disable images.
+- **Cost Controls:** Local asset cache, Keeper auto-trigger (switch to manual anytime), quick command picker, offline placeholders if you disable images.
 
 ---
 
@@ -69,7 +69,7 @@ Edit
   - **Browser (free)** — system voices, zero cost.
   - **ElevenLabs** — premium quality. Set API key + voice ID. All audio is cached locally and replayable.
   - **None** — silent mode.
-- **Keeper Trigger:** `Manual` (click **Ask Keeper** or `/keeper …`) or `Auto` (Keeper replies to normal messages).
+- **Keeper Trigger:** `Auto` (Keeper replies to normal messages) or `Manual` (click **Ask Keeper** or `/keeper …`).
 - **Keeper Style/Max Tokens:** Control verbosity and token budget to reduce spend.
 - **Rules Pack:** Your own notes/house-rules (do not paste copyrighted text).
 


### PR DESCRIPTION
## Summary
- Have the Keeper reply automatically by default for more natural play
- Update settings documentation to note the auto Keeper trigger

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989a8e6644833189f89140c542aa7f