### PR TITLE
Simplify save/load modal to rely on slots and import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,10 +300,6 @@
   <div class="scrim" data-close="#modalSave"></div>
   <div class="sheet">
     <h2>Save / Load</h2>
-    <div class="row" style="margin-bottom:.5rem">
-      <button id="btnSave" class="ghost">Save</button>
-      <button id="btnLoad" class="warn">Load</button>
-    </div>
     <div class="slots" id="slots"></div>
     <div class="hr"></div>
     <div class="grid2">

--- a/js/app.js
+++ b/js/app.js
@@ -7,7 +7,6 @@
 /* ---------- CONSTANTS ---------- */
 const LS_SETTINGS = 'si_settings_v8';
 const LS_SLOTS    = 'si_slots_v6';
-const LS_QUICK    = 'si_quicksave_v1';
 const LS_WIZARD   = 'si_wizard_done_v6';
 const LS_ARC_FP   = 'si_recent_arc_fps_v2';
 const GRID_W = 12, GRID_H = 8;
@@ -731,21 +730,8 @@ function applyState(data){
 function saveToSlot(i){ const slots=loadSlots(); slots[i]=captureState(); saveSlots(slots); updateSlots(); toast('Saved.'); }
 function loadFromSlot(i){ const slots=loadSlots(); if(!slots[i]){ toast('Empty slot'); return; } applyState(slots[i]); toast('Loaded.'); }
 function clearSlot(i){ const slots=loadSlots(); slots[i]=null; saveSlots(slots); updateSlots(); }
-function saveLocal(){
-  localStorage.setItem(LS_QUICK, JSON.stringify(captureState()));
-  toast('Saved.');
-  hide('#modalSave');
-}
-function loadLocal(){
-  const raw = localStorage.getItem(LS_QUICK);
-  if(!raw){ toast('No save'); return; }
-  try{ applyState(JSON.parse(raw)); toast('Loaded.'); hide('#modalSave'); }
-  catch{ toast('Bad save'); }
-}
 byId('btnExport').onclick=()=>{ const blob=new Blob([JSON.stringify(captureState(),null,2)],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='solo-investigator-save.json'; a.click(); setTimeout(()=>URL.revokeObjectURL(url), 2000); };
 byId('btnImport').onclick=()=>{ try{ const data=JSON.parse(byId('importText').value.trim()); applyState(data); toast('Imported.'); }catch{ toast('Bad JSON'); } };
-byId('btnSave').onclick=saveLocal;
-byId('btnLoad').onclick=loadLocal;
 
 /* ---------- IMAGES (Data URLs; cached) ---------- */
 async function openaiImage(prompt, size='1024x1024'){


### PR DESCRIPTION
## Summary
- Remove redundant Save/Load buttons from the modal
- Drop quick-save logic and its storage key
- Keep local saves via slots and file saves via import/export controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ac0fe47483318c266feb90016ebd