### PR TITLE
Fix chat panel height

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,6 +44,7 @@
   .panel{background:linear-gradient(180deg, var(--panel), var(--panel-2));border:1px solid #1a2130;border-radius:12px;padding:1rem;box-shadow:var(--glow)}
   .panel h2{margin:.25rem 0 1rem 0;font-size:1rem;color:#c9d6f7}
   .leftcol,.rightcol{display:flex;flex-direction:column;gap:1rem}
+  .leftcol > .panel{flex:1;display:flex;flex-direction:column}
 
   /* Map */
   #mapWrap{position:relative;border-radius:12px;overflow:hidden}
@@ -82,7 +83,7 @@
     color:#cfe1ff;font-size:.75rem}
 
   /* Chat (fixed height + scrollbar) */
-  #chat{display:flex;flex-direction:column;height:100%}
+  #chat{display:flex;flex-direction:column;flex:1}
   #chatLog{
     flex:1; /* fill remaining space */
     overflow-y:auto;


### PR DESCRIPTION
## Summary
- Keep chat panel aligned with map by letting left column panel flex to full height.
- Ensure chat container fills available space and scrolls instead of expanding.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b636e9e08331b62304b0b38b1ab0