### PR TITLE
Add sanity thresholds, clue journal, and whispers

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <button id="btnParty">Party</button>
     <button id="btnNPCs">NPCs</button>
     <button id="btnHandouts">Handouts</button>
+    <button id="btnClues">Clues</button>
     <button id="btnSaveLoad">Save/Load</button>
     <span class="pill">Shortcuts: <span class="kbd">V</span> select · <span class="kbd">R</span> ruler · <span class="kbd">F</span> reveal · <span class="kbd">H</span> hide · <span class="kbd">U</span> undo</span>
   </nav>
@@ -82,6 +83,7 @@
         <button id="btnCenter" class="ghost">Center Tokens</button>
         <button id="btnParticles" class="ghost">Ping FX</button>
         <button id="btnGenBG" class="primary">Generate Background</button>
+        <button id="btnOmen" class="ghost">Random Omen</button>
       </div>
       <div class="row" style="margin-top:.5rem">
         <button id="btnRevealAll" class="success">Reveal All</button>
@@ -278,7 +280,7 @@
     <div id="npcList" class="small" style="margin-top:.5rem"></div>
     <div class="hr"></div>
     <div class="row right"><button class="ghost" data-close="#modalNPCs">Close</button></div>
-  </div>
+</div>
 </div>
 
 <!-- HANDOUTS -->
@@ -292,6 +294,22 @@
     <div id="handoutsList" class="small" style="margin-top:.5rem"></div>
     <div class="hr"></div>
     <div class="row right"><button class="ghost" data-close="#modalHandouts">Close</button></div>
+</div>
+</div>
+
+<!-- CLUES -->
+<div class="modal" id="modalClues">
+  <div class="scrim" data-close="#modalClues"></div>
+  <div class="sheet">
+    <h2>Clue Journal</h2>
+    <div id="clueList" class="col" style="margin-bottom:.5rem"></div>
+    <div class="row" style="margin-top:.5rem">
+      <input id="clueTitle" placeholder="Title"/>
+      <input id="clueText" placeholder="Details"/>
+      <button id="btnAddClue" class="ghost">Add</button>
+    </div>
+    <div class="hr"></div>
+    <div class="row right"><button class="ghost" data-close="#modalClues">Close</button></div>
   </div>
 </div>
 
@@ -331,6 +349,8 @@
           <input id="csArch"/>
           <label>Persona / Notes</label>
           <textarea id="csPersona" rows="4"></textarea>
+          <label>Bonds</label>
+          <input id="csBonds" placeholder="family, debts"/>
         </div>
       </div>
       <div class="card">

--- a/style.css
+++ b/style.css
@@ -93,6 +93,8 @@
   #chatLog .line{display:flex;align-items:flex-start;gap:.6rem;margin:.45rem 0}
   #chatLog .line.action{font-style:italic;color:var(--muted);background:#0c121d;border-radius:4px;padding:.2rem .4rem}
   #chatLog .line.system{color:var(--muted)}
+  #chatLog .line.whisper{font-style:italic;opacity:.85;background:#221a0f;border-radius:4px;padding:.2rem .4rem}
+  #chatLog .line.whisper .who{color:#ffd29d}
   #chatLog .who{opacity:.85;font-weight:600}
   #chatLog .content{flex:1}
   #chatLog .controls{display:flex;gap:.25rem}
@@ -128,6 +130,8 @@
   #handoutsList img{max-width:100%;height:auto;border:1px solid #1a2231;border-radius:8px;display:block;margin:.35rem 0}
   #handoutsList .ho{border:1px solid #223049;border-radius:10px;padding:.6rem;margin:.5rem 0;background:#0f1525}
   #handoutsList .ho h4{margin:.25rem 0 .3rem 0}
+  #clueList .clue{border:1px solid #223049;border-radius:10px;padding:.6rem;margin:.5rem 0;background:#0f1525}
+  #clueList .clue h4{margin:.25rem 0 .3rem 0}
   .chat-handout img{max-width:100%;height:auto;border:1px solid #1a2231;border-radius:8px;margin-top:.35rem}
 
   /* Progress */


### PR DESCRIPTION
## Summary
- Track investigation leads with a new Clue Journal and random omen generator for atmospheric hooks
- Introduce sanity thresholds that add conditions and bonds for deeper role-play
- Support private Keeper whispers and 1920s-flavored prompts with bonus actions

## Testing
- `node --check js/app.js`
- `node --check js/keeper.js`


------
https://chatgpt.com/codex/tasks/task_e_689910c343588331aa7ec03f09f5d2a9