### PR TITLE
Fix movement, dice validation, and engine parsing

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -133,7 +133,16 @@ YOU are: ${you? you.name+' ('+(you.persona||you.sheet?.persona||'no persona')+')
 Rules notes: """${state.settings.rulesPack||''}"""
 `;
 }
-function parseEngine(text){ const m=text.match(/<engine>([\s\S]+?)<\/engine>/i); if(!m) return null; try{ return JSON.parse(m[1]); }catch{ return null; } }
+function parseEngine(text){
+  const m=text.match(/<engine>([\s\S]+?)<\/engine>/i);
+  if(!m) return null;
+  try{
+    return JSON.parse(m[1]);
+  }catch(err){
+    console.error('Bad engine JSON', err);
+    return null;
+  }
+}
 function applyEngine(eng){
   if(eng.say){
     eng.say.forEach(s=> {
@@ -149,7 +158,12 @@ function applyEngine(eng){
     });
   }
   if(eng.moves){ eng.moves.forEach(m=>{ const t=currentScene().tokens.find(x=>x.id===m.tokenId); if(t){ tryMoveCommand(t, m.to?.[0], m.to?.[1]); } }); }
-  if(eng.rollRequests){ eng.rollRequests.forEach(r=> doRoll('1d100', {who:'keeper', note:`${r.character||'PC'} ${r.skill?`(${r.skill})`:''}`})); }
+  if(eng.rollRequests){
+    eng.rollRequests.forEach(r=>{
+      const modStr = r.mod ? (r.mod >= 0 ? `+${r.mod}` : `${r.mod}`) : '';
+      doRoll(`1d100${modStr}`, {who:'keeper', note:`${r.character||'PC'}${r.skill?` (${r.skill})`:''}`});
+    });
+  }
   if(eng.handouts){ eng.handouts.forEach(h=>{ if(typeof h==='number') dropHandout(h); else if(h && h.title){ state.campaign=state.campaign||{}; state.campaign.handouts=state.campaign.handouts||[]; state.campaign.handouts.push(h); renderHandouts(); dropHandout(state.campaign.handouts.length-1); } }); }
   if(eng.items){ eng.items.forEach(it=>{ const t=currentScene().tokens.find(x=>x.id===it.tokenId); if(!t) return; ensureSheet(t); t.sheet.inventory=t.sheet.inventory||[]; const existing=t.sheet.inventory.find(x=>x.name===it.name); if(existing){ existing.qty=(existing.qty||0)+(it.qty||1); } else { t.sheet.inventory.push({name:it.name, qty:it.qty||1, weight:it.weight||0}); } }); }
   if(eng.stats){ eng.stats.forEach(st=>{ const t=currentScene().tokens.find(x=>x.id===st.tokenId); if(!t) return; ensureSheet(t); for(const k in st){ if(k!=='tokenId'){ t.sheet[k]=(t.sheet[k]||0)+(st[k]||0); } } checkSanityThresholds(t); }); }


### PR DESCRIPTION
## Summary
- Correct movement cost by accounting for actual distance traveled
- Log player questions in chat when using the Ask Keeper shortcut
- Add dice expression validation and size limits
- Honor roll modifiers and improve engine JSON parsing

## Testing
- `node --check js/app.js`
- `node --check js/keeper.js`


------
https://chatgpt.com/codex/tasks/task_e_6899171d8aa08331aa727834aaa32869