### PR TITLE
Expand default skill list for richer gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,11 +35,12 @@
             <option value="/roll 1d20">Roll 1d20</option>
             <option value="/roll 3d6">Roll 3d6</option>
             <option value="/check Spot 60">Check Spot 60</option>
+            <option value="/check Listen 55">Check Listen 55</option>
             <option value="/endturn">End Turn</option>
             <option value="/help">Help</option>
           </select>
           <button id="cmdInsert" class="ghost">Insert</button>
-          <input id="chatInput" placeholder="Say something… (try /roll 1d100, /check Spot 60, /keeper What do we notice?)" />
+          <input id="chatInput" placeholder="Say something… (try /roll 1d100, /check Spot 60, /check Listen 55, /keeper What do we notice?)" />
           <button class="primary" id="chatSend">Send</button>
           <button class="ghost" id="btnAskKeeper" title="Ask Keeper without sending more tokens by default">Ask Keeper</button>
           <button class="ghost" id="btnStopVoice" title="Stop voices & clear queue">Stop Voice</button>

--- a/js/app.js
+++ b/js/app.js
@@ -1255,7 +1255,23 @@ function defaultSheet(t){
     persona: t.persona||'',
     hp: 10, sanity: 50, speed: t.speed||4,
     attrs:{Brains:10,Brawn:10,Nerve:10,Perception:10,Charm:10},
-    skills:{Spot:60,Stealth:40,Medicine:30,Library:50,Persuade:40},
+    skills:{
+      Spot:60,
+      Stealth:40,
+      Medicine:30,
+      Library:50,
+      Persuade:40,
+      Listen:55,
+      Occult:25,
+      History:35,
+      Intimidate:45,
+      FirstAid:55,
+      Survival:30,
+      Firearms:40,
+      Mechanical:20,
+      Driving:40,
+      Climb:35
+    },
     inventory:[], conditions:[], bonds:[]
   };
 }
@@ -1392,7 +1408,7 @@ byId('brush').addEventListener('change',e=> brush=Number(e.target.value));
 /* Begin play banner */
 function greetAndStart(){
   addSystemMessage(`<b>${escapeHtml(state.campaign?.title||'Welcome')}</b><br>${escapeHtml(state.campaign?.logline||'Learn the basics with the Keeper’s help.')}`);
-  addSystemMessage(`Use <i>Start Encounter</i> for guided turns. On your turn: move up to <b>4</b> tiles, take <b>1</b> action and <b>1</b> bonus action, then type <i>/endturn</i>. For skill checks, try <i>/check Spot 60</i>.`);
+  addSystemMessage(`Use <i>Start Encounter</i> for guided turns. On your turn: move up to <b>4</b> tiles, take <b>1</b> action and <b>1</b> bonus action, then type <i>/endturn</i>. For skill checks, try <i>/check Spot 60</i> or <i>/check Listen 55</i>.`);
 }
 
 /* Boot */

--- a/js/keeper.js
+++ b/js/keeper.js
@@ -173,7 +173,7 @@ function applyEngine(eng){
 function demoKeeper(userText){
   const tips=[
    "You can move up to 4 tiles on your turn. Try <i>/endturn</i> when done.",
-   "Try a careful search. Use <i>/roll 1d100</i> or <i>/check Spot 60</i>.",
+   "Try a careful search. Use <i>/roll 1d100</i> or <i>/check Spot 60</i> or <i>/check Listen 55</i>.",
    "Consider talking to an NPC; short questions reveal clues."
   ];
   return `A faint draft lifts the dust. ${tips[Math.floor(Math.random()*tips.length)]}

--- a/readme.md
+++ b/readme.md
@@ -81,10 +81,10 @@ readme.md    - documentation
    - Use **Start Encounter** to enter turn mode.
    - Companions/NPCs act **automatically** on their turns. You can speak or move your PC on your turn.
    - Use slash commands in chat:
-     - `/roll 1d100` or `/roll 3d6+2`
-     - `/check Spot 60`
-     - `/keeper What do we notice?`
-     - `/endturn`
+    - `/roll 1d100` or `/roll 3d6+2`
+    - `/check Spot 60` or `/check Listen 55`
+    - `/keeper What do we notice?`
+    - `/endturn`
    - Use **fog tools**, **ruler**, and **pings** for tactics.
 
 ---


### PR DESCRIPTION
## Summary
- Triple the default skill list to 15 entries, adding listening, historical, survival, and technical abilities.
- Expose new skills in quick commands, tutorial tips, and greeting message so players can try them immediately.
- Document the expanded skill system and new command example.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991a74d49483318cad6f224efdd6fe