### PR TITLE
feat: add kokoro asset download wizard

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -719,6 +719,7 @@ function voiceControlsForName(actor){
     const idVal = (provSel.value==='browser' || provSel.value==='kokoro')? voiceSel.value : (provSel.value==='eleven'? voiceInp.value.trim(): '');
     state.settings.voiceMap[name] = {provider: provSel.value, id: idVal};
     saveSettings();
+    refreshKokoroButton();
   }
   provSel.onchange=()=>{ fillVoiceOptions(); refreshVis(); updateMap(); };
   voiceSel.onchange=updateMap;
@@ -1067,6 +1068,9 @@ function renderWizard(){
     const voiceSetup=el('div',{class:'card'},[
       el('h3',{},'Voice Setup (optional, per speaker)'),
       el('div',{class:'small'},'Pick Browser voices (free) or enter ElevenLabs IDs per character.'),
+      el('div',{class:'row',style:'margin-top:.35rem'},[
+        el('button',{id:'btnKokoroAssets',class:'ghost',onclick:downloadKokoroAssets},'Download Kokoro Voices (~120MB)')
+      ]),
       el('div',{id:'voiceSetupRows'})
     ]);
     body.appendChild(el('div',{class:'card'},[
@@ -1170,6 +1174,33 @@ function renderVoiceSetup(){
   actors.forEach(a=>{
     wrap.appendChild(voiceControlsForName(a));
   });
+  refreshKokoroButton();
+}
+
+async function downloadKokoroAssets(){
+  const btn = byId('btnKokoroAssets'); if(!btn) return;
+  btn.disabled = true; btn.textContent = 'Downloading...';
+  try{
+    const {session} = await ensureKokoro();
+    if(session){
+      btn.textContent = 'Kokoro Ready';
+      renderVoiceSetup();
+    }else{
+      btn.textContent = 'Download failed';
+      btn.disabled = false;
+    }
+  }catch(err){
+    console.warn('Kokoro download failed', err);
+    btn.textContent = 'Download failed';
+    btn.disabled = false;
+  }
+}
+
+function refreshKokoroButton(){
+  const btn = byId('btnKokoroAssets'); if(!btn) return;
+  const map = state.settings.voiceMap || {};
+  const any = Object.values(map).some(m=>m.provider==='kokoro');
+  btn.style.display = any ? 'inline-block' : 'none';
 }
 
 /* ---------- STORY ARC (AI) with variety & anti-repetition ---------- */

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ See **`agents.md`** for full prompts and engine schema.
 - **Queue & Replay:** When TTS is on and queueing is enabled, lines won’t overlap. Each chat line has a ▶ replay button if a voice is available for that speaker.
 - **Per-Speaker Mapping:** Set provider and voice per speaker (Keeper + each PC/NPC) in **Party**.
 - **Cost Control:** Prefer **Browser** or **Kokoro** for routine chatter; reserve **ElevenLabs** for key moments. The app caches ElevenLabs audio locally to avoid re-charges.
+ - **Kokoro Setup:** Use the wizard's "Download Kokoro Voices" button to fetch the open model (~120 MB) before assigning Kokoro voices.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Download Kokoro Voices button to the wizard's voice setup
- only show the download button when a Kokoro voice is selected and refresh voice list after download
- document Kokoro download step in README

## Testing
- `node --check js/app.js`
- `node --check js/kokoro.js`


------
https://chatgpt.com/codex/tasks/task_e_68994d9ff8a08331bba7484b4be5d7f4