### PR TITLE
Fix Kokoro ort import for TTS

### DIFF
--- a/js/kokoro.js
+++ b/js/kokoro.js
@@ -30,13 +30,15 @@ const KOKORO_VOICE_LIST = [
 
 window.KOKORO_VOICES = window.KOKORO_VOICES || [];
 let kokoroInit = null;
+let ort;
 
 async function ensureKokoro(){
   if(!kokoroInit){
     kokoroInit = (async()=>{
       try{
-        if(!window.ort){
-          await import('https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js');
+        if(!ort){
+          ort = await import('https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js');
+          window.ort = ort;
         }
         // Load helper libs for phonemization and npy/npz parsing
         const [{phonemize}, {unzipSync}, npyjsMod, config] = await Promise.all([


### PR DESCRIPTION
## Summary
- ensure onnxruntime-web import assigns `ort` globally so Kokoro uses it

## Testing
- `node --check js/kokoro.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995459aee48331a6d2b19d6c54f66a