### PR TITLE
Fix chat panel overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,9 @@
     color:var(--ink);
     font-family:system-ui,-apple-system,Segoe UI,Inter,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif;
     letter-spacing:.15px;
+    display:flex;
+    flex-direction:column;
+    height:100vh;
   }
   a{color:var(--brand)}
   button,select,input,textarea{
@@ -38,13 +41,13 @@
   header.appbar nav{display:flex;gap:.5rem;flex-wrap:wrap}
   header.appbar nav button{padding:.45rem .6rem}
 
-  .container{display:grid;grid-template-columns:320px 1fr 360px;gap:1rem;padding:1rem;align-items:stretch}
+  .container{display:grid;grid-template-columns:320px 1fr 360px;gap:1rem;padding:1rem;align-items:stretch;flex:1;min-height:0}
   @media (max-width: 1100px){ .container{grid-template-columns:1fr} }
 
   .panel{background:linear-gradient(180deg, var(--panel), var(--panel-2));border:1px solid #1a2130;border-radius:12px;padding:1rem;box-shadow:var(--glow)}
   .panel h2{margin:.25rem 0 1rem 0;font-size:1rem;color:#c9d6f7}
-  .leftcol,.rightcol{display:flex;flex-direction:column;gap:1rem}
-  .leftcol > .panel{flex:1;display:flex;flex-direction:column}
+  .leftcol,.rightcol{display:flex;flex-direction:column;gap:1rem;min-height:0}
+  .leftcol > .panel{flex:1;display:flex;flex-direction:column;min-height:0}
 
   /* Map */
   #mapWrap{position:relative;border-radius:12px;overflow:hidden}
@@ -83,7 +86,7 @@
     color:#cfe1ff;font-size:.75rem}
 
   /* Chat (fixed height + scrollbar) */
-  #chat{display:flex;flex-direction:column;flex:1}
+  #chat{display:flex;flex-direction:column;flex:1;min-height:0}
   #chatLog{
     flex:1; /* fill remaining space */
     overflow-y:auto;


### PR DESCRIPTION
## Summary
- Keep the page layout to the viewport height and allow the chat panel to scroll within its pane.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997149c1b88331bcda615c8b042d59