### PR TITLE
Fix chat panel scrolling and remove stray engine tags

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -195,7 +195,10 @@ async function keeperReply(userText){
       if(!res.ok) throw new Error(await res.text());
       const data=await res.json(); text=data.choices?.[0]?.message?.content || '…';
     }else{ text=demoKeeper(userText); }
-    const narr = text.replace(/<engine[^>]*>[\s\S]*?<\/engine\s*>/i,'').trim();
+    const narr = text
+      .replace(/<engine[^>]*>[\s\S]*?<\/engine\s*>/gi, '')
+      .replace(/<\/engine>/gi, '')
+      .trim();
     if(narr) addLine(narr,'keeper',{speaker:'Keeper', role:'npc'});
     const eng=parseEngine(text); if(eng) applyEngine(eng);
     if(state.settings.ttsOn && narr) speak(stripTags(narr),'Keeper','npc');
@@ -203,7 +206,10 @@ async function keeperReply(userText){
   }catch(err){
     addSystemMessage("The air stills… (AI call failed; offline demo).");
     const demo=demoKeeper(userText);
-    const narr = demo.replace(/<engine[^>]*>[\s\S]*?<\/engine\s*>/i, '').trim();
+    const narr = demo
+      .replace(/<engine[^>]*>[\s\S]*?<\/engine\s*>/gi, '')
+      .replace(/<\/engine>/gi, '')
+      .trim();
     if(narr) addLine(narr, 'keeper', { speaker: 'Keeper', role: 'npc' });
     const eng = parseEngine(demo);
     if(eng) applyEngine(eng);

--- a/style.css
+++ b/style.css
@@ -86,7 +86,7 @@
     color:#cfe1ff;font-size:.75rem}
 
   /* Chat (fixed height + scrollbar) */
-  #chat{display:flex;flex-direction:column;flex:1;min-height:0}
+  #chat{display:flex;flex-direction:column;flex:1;min-height:0;overflow:hidden}
   #chatLog{
     flex:1; /* fill remaining space */
     overflow-y:auto;


### PR DESCRIPTION
## Summary
- Prevent chat area from expanding endlessly by hiding overflow on the chat container
- Strip extra `<engine>` tags from Keeper responses so only narrative appears in chat

## Testing
- `node --check js/keeper.js`
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6899763e9a80833193c928fca4806219