### PR TITLE
fix: address various runtime issues

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -77,10 +77,14 @@ async function executeAITurn(actor){
 async function applyEngineResponse(eng, actor){
   if(eng.perform){
     addActionLine(`* ${actor.name} ${eng.perform} *`);
+    state.encounter.actionsLeft = Math.max(0, state.encounter.actionsLeft - 1);
+    updateTurnBanner();
     await new Promise(r=>setTimeout(r,700));
   }
   if(eng.bonus){
     addActionLine(`* ${actor.name} ${eng.bonus} (bonus) *`);
+    state.encounter.bonusLeft = Math.max(0, state.encounter.bonusLeft - 1);
+    updateTurnBanner();
     await new Promise(r=>setTimeout(r,700));
   }
   if(eng.move && eng.move.to){


### PR DESCRIPTION
## Summary
- clamp grid conversions to stay within the board
- reset encounter state and initiative when combat ends
- respect zero speed and update action budgets for AI turns
- avoid keyboard shortcuts while typing and reset quick command picker

## Testing
- `node --check js/app.js`
- `node --check js/keeper.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899d4cdb61483318f8ef0f7eaf131b6