### PR TITLE
Improve save system and import/export handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,12 +333,17 @@
     <div class="grid2">
       <div class="col">
         <label>Export (download JSON file)</label>
-        <button id="btnExport" class="ghost">Export Now</button>
+        <button id="btnExport" class="ghost">Export Current</button>
+        <button id="btnExportSlots" class="ghost" style="margin-top:.5rem">Export Slots</button>
       </div>
       <div class="col">
         <label>Import (paste JSON)</label>
         <textarea id="importText" rows="6" placeholder="{...}"></textarea>
-        <div class="row right"><button id="btnImport" class="primary">Import</button></div>
+        <div class="row right"><button id="btnImport" class="primary">Import Text</button></div>
+        <label style="margin-top:.5rem">Import from File</label>
+        <input id="importFile" type="file" accept="application/json"/>
+        <label style="margin-top:.5rem">Import Slots File</label>
+        <input id="importSlotsFile" type="file" accept="application/json"/>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -157,6 +157,8 @@
   /* Save slots */
   .slots{display:grid;grid-template-columns:1fr 1fr;gap:.5rem}
   .slots .slot{display:flex;gap:.5rem;align-items:center;justify-content:space-between;border:1px dashed #2b3650;border-radius:10px;padding:.4rem .6rem;background:#0c121c}
+  .slots .slot.used{border-style:solid}
+  .slots .slot .row button[disabled]{opacity:.4;cursor:not-allowed}
   .slots .meta{display:flex;flex-direction:column}
   .slots .ts{font-size:.75rem;color:#8ea0bf}
 


### PR DESCRIPTION
## Summary
- Add robust save slot handling with error checks and disabled actions for empty slots
- Deep-clone game state and support exporting/importing slots and saves via files
- Update styles and markup for new save/load controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e21bed308331b36c3835e65539ea