### PR TITLE
Fix chat serialization and AI output escaping

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -158,9 +158,9 @@ function applyEngine(eng){
       const text = s.text || '';
       const role = s.role || 'pc';
       if(s.to){
-        addWhisper(s.to, `${speaker}: ${escapeHtml(text)}`);
+        addWhisper(s.to, `${speaker}: ${text}`);
       }else{
-        addSay(speaker, escapeHtml(text), role);
+        addSay(speaker, text, role);
         if(state.settings.ttsOn) speak(stripTags(text), speaker, role);
       }
     });


### PR DESCRIPTION
## Summary
- Track speaker roles via `data-role` attributes instead of color and capture whisper lines
- Store chat text instead of HTML to avoid double escapes and restore whispers
- Center generated avatar initials
- Avoid double escaping AI-generated text in `applyEngine`

## Testing
- `node -c js/app.js`
- `node -c js/keeper.js`


------
https://chatgpt.com/codex/tasks/task_e_689a2537b3408331b7471e301457a4c2