### PR TITLE
Revamp save interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,23 +340,30 @@
 <div class="modal" id="modalSave">
   <div class="scrim" data-close="#modalSave"></div>
   <div class="sheet">
-    <h2>Save / Load</h2>
+    <h2>Save &amp; Load</h2>
+    <p class="small thin">Store up to six campaigns locally. Export or import JSON to transfer games.</p>
     <div class="slots" id="slots"></div>
     <div class="hr"></div>
     <div class="grid2">
-      <div class="col">
-        <label>Export (download JSON file)</label>
-        <button id="btnExport" class="ghost">Export Current</button>
-        <button id="btnExportSlots" class="ghost" style="margin-top:.5rem">Export Slots</button>
+      <div class="card">
+        <h3>Export</h3>
+        <p class="small">Download saves as JSON files.</p>
+        <div class="col">
+          <button id="btnExport" class="ghost">💾 Export Current</button>
+          <button id="btnExportSlots" class="ghost">📦 Export All Slots</button>
+        </div>
       </div>
-      <div class="col">
-        <label>Import (paste JSON)</label>
-        <textarea id="importText" rows="6" placeholder="{...}"></textarea>
-        <div class="row right"><button id="btnImport" class="primary">Import Text</button></div>
-        <label style="margin-top:.5rem">Import from File</label>
-        <input id="importFile" type="file" accept="application/json"/>
-        <label style="margin-top:.5rem">Import Slots File</label>
-        <input id="importSlotsFile" type="file" accept="application/json"/>
+      <div class="card">
+        <h3>Import</h3>
+        <p class="small">Paste JSON or upload a file.</p>
+        <div class="col">
+          <textarea id="importText" rows="6" placeholder="{...}"></textarea>
+          <div class="row right"><button id="btnImport" class="primary">Import Text</button></div>
+          <label>Import from File</label>
+          <input id="importFile" type="file" accept="application/json"/>
+          <label>Import Slots File</label>
+          <input id="importSlotsFile" type="file" accept="application/json"/>
+        </div>
       </div>
     </div>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -1031,13 +1031,14 @@ function updateSlots(){
     const used = !!slot;
     const row = el('div',{class:'slot'+(used?' used':'')},[
       el('div',{class:'meta'},[
-        el('div',{}, `Slot ${i+1}: ${used? (slot.meta?.name||'Campaign'): '\u2014 empty \u2014'}`),
+        el('div',{class:'slotname'},`Slot ${i+1}`),
+        el('div',{class:'title'}, used? (slot.meta?.name||'Campaign') : 'Empty'),
         el('div',{class:'ts'}, used? new Date(slot.meta?.ts||Date.now()).toLocaleString(): '')
       ]),
-      el('div',{class:'row'},[
-        el('button',{class:'ghost',onclick:()=> saveToSlot(i)},'Save'),
-        el('button',{class:'warn',onclick:()=> loadFromSlot(i),disabled:!used},'Load'),
-        el('button',{class:'danger',onclick:()=> clearSlot(i),disabled:!used},'Clear')
+      el('div',{class:'row buttons'},[
+        el('button',{class:'ghost',onclick:()=> saveToSlot(i)},'\uD83D\uDCBE Save'),
+        el('button',{class:'warn',onclick:()=> loadFromSlot(i),disabled:!used},'\uD83D\uDCC2 Load'),
+        el('button',{class:'danger',onclick:()=> clearSlot(i),disabled:!used},'\uD83D\uDDD1\uFE0F Clear')
       ])
     ]);
     wrap.appendChild(row);

--- a/style.css
+++ b/style.css
@@ -168,11 +168,15 @@
   .stepItem.cur .dot{background:#7aa2ff;border-color:#4869a7}
 
   /* Save slots */
-  .slots{display:grid;grid-template-columns:1fr 1fr;gap:.5rem}
-  .slots .slot{display:flex;gap:.5rem;align-items:center;justify-content:space-between;border:1px dashed #2b3650;border-radius:10px;padding:.4rem .6rem;background:#0c121c}
+  .slots{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem}
+  .slots .slot{display:flex;flex-direction:column;gap:.5rem;border:1px dashed #2b3650;border-radius:10px;padding:.6rem;background:#0c121c}
   .slots .slot.used{border-style:solid}
-  .slots .slot .row button[disabled]{opacity:.4;cursor:not-allowed}
-  .slots .meta{display:flex;flex-direction:column}
+  .slots .meta{display:flex;flex-direction:column;gap:.15rem}
+  .slots .meta .slotname{font-size:.75rem;color:var(--muted)}
+  .slots .meta .title{font-weight:600}
+  .slots .slot .buttons{display:flex;gap:.5rem}
+  .slots .slot .buttons button{flex:1}
+  .slots .slot .buttons button[disabled]{opacity:.4;cursor:not-allowed}
   .slots .ts{font-size:.75rem;color:#8ea0bf}
 
   /* Toast */


### PR DESCRIPTION
## Summary
- Restyle Save & Load modal with clearer card layout and helpful descriptions
- Add slot labels, timestamps, and icons to save/load buttons
- Upgrade save slot grid styling for better readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b2805d9c0833188319879ba323be8