### PR TITLE
Fix AI movement and voice mapping bugs

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -80,13 +80,13 @@ async function executeAITurn(actor){
 }
 
 async function applyEngineResponse(eng, actor){
-  if(eng.perform){
+  if(eng.perform && state.encounter.actionsLeft>0){
     addActionLine(`* ${actor.name} ${eng.perform} *`);
     state.encounter.actionsLeft = Math.max(0, state.encounter.actionsLeft - 1);
     updateTurnBanner();
     await new Promise(r=>setTimeout(r,700));
   }
-  if(eng.bonus){
+  if(eng.bonus && state.encounter.bonusLeft>0){
     addActionLine(`* ${actor.name} ${eng.bonus} (bonus) *`);
     state.encounter.bonusLeft = Math.max(0, state.encounter.bonusLeft - 1);
     updateTurnBanner();


### PR DESCRIPTION
## Summary
- Prevent dragging non-active tokens during encounters
- Clamp programmatic moves to the grid and adjust movement text
- Preserve voice settings when renaming PCs and NPCs
- Skip AI actions and bonuses when no budget remains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b3e4abb288331b826a736f1d988ce