### PR TITLE
Add Keeper introduction at story start

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1921,6 +1921,7 @@ byId('brush').addEventListener('change',e=> brush=Number(e.target.value));
 function greetAndStart(){
   addSystemMessage(`<b>${escapeHtml(state.campaign?.title||'Welcome')}</b><br>${escapeHtml(state.campaign?.logline||'Learn the basics with the Keeper’s help.')}`, {html:true});
   addSystemMessage(`Use <i>Start Encounter</i> for guided turns. On your turn: move up to <b>4</b> tiles, take <b>1</b> action and <b>1</b> bonus action, then type <i>/endturn</i>. For skill checks, try <i>/check Spot</i> or <i>/check Listen</i>. Refresh Luck with <i>/luck</i> (once per game) and spend it after a failed roll with <i>/spendluck 5</i>.`, {html:true});
+  keeperReply('Give a brief introduction describing the characters and the scene so the player knows the setup.');
 }
 
 /* Boot */

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ A modular, client-only tabletop experience inspired by investigative horror RPGs
 - **Persona-Driven Agents:** Each AI character gets a tailored prompt (skills, persona, map position, recent events) to feel distinct.
 - **Shared Memory & Voice:** Keeper, companions, and NPCs recall past events and party members to speak in a more colorful, in-character way.
 - **Keeper Guidance:** A friendly tutorial Keeper that nudges you with clear next actions (manual or auto-trigger).
+- **Opening Introduction:** At the start of each story, the Keeper summarizes the characters and scene to set the stage.
 - **Handouts in Chat:** Keeper can drop handouts directly into chat and update party inventory and stats automatically.
 - **System Messages:** Generic engine notices (start prompts, dice rolls, invalid moves) appear as ⚙️ lines, separate from the Keeper.
 - **Tactical Board:** Grid, fog of war (reveal/hide/undo), ruler, pings, tokens w/ portraits, active-turn highlight, movement budgets.


### PR DESCRIPTION
## Summary
- Have the Keeper automatically introduce the characters and scene when play begins.
- Document the new opening introduction feature in the highlights.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b46e5c40083319a607867aab951a0