### PR TITLE
feat: regenerate scene background from Keeper narration

### DIFF
--- a/js/keeper.js
+++ b/js/keeper.js
@@ -281,7 +281,10 @@ async function keeperReply(userText){
       .replace(/<engine[^>]*>[\s\S]*?(?:<\/engine\s*>|$)/gi, '')
       .replace(/<\/engine>/gi, '')
       .trim();
-    if(narr) addLine(narr,'keeper',{speaker:'Keeper', role:'npc'});
+    if(narr){
+      addLine(narr,'keeper',{speaker:'Keeper', role:'npc'});
+      maybeSetSceneBackground(narr);
+    }
     const eng=parseEngine(text); if(eng) applyEngine(eng);
     if(state.settings.ttsOn && narr) speak(stripTags(narr),'Keeper','npc');
     maybeSummarizeLocal(); // keep memory fresh without extra tokens
@@ -292,7 +295,10 @@ async function keeperReply(userText){
       .replace(/<engine[^>]*>[\s\S]*?(?:<\/engine\s*>|$)/gi, '')
       .replace(/<\/engine>/gi, '')
       .trim();
-    if(narr) addLine(narr, 'keeper', { speaker: 'Keeper', role: 'npc' });
+    if(narr){
+      addLine(narr, 'keeper', { speaker: 'Keeper', role: 'npc' });
+      maybeSetSceneBackground(narr);
+    }
     const eng = parseEngine(demo);
     if(eng) applyEngine(eng);
     maybeSummarizeLocal();


### PR DESCRIPTION
## Summary
- Track scene background prompts in memory
- Auto-regenerate backgrounds when Keeper narration changes the setting
- Hook Keeper replies to update stored prompts and trigger image generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c99c5c8e48331a3f3300316be1345