### PR TITLE
Add speech-to-text microphone button to chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
           </select>
           <button id="cmdInsert" class="ghost">Insert</button>
           <input id="chatInput" placeholder="Say something… (try /roll 1d100, /check Spot, /check Listen, /luck, /spendluck 5, /keeper What do we notice?)" />
+          <button class="ghost" id="btnSpeech" title="Speak message">🎤</button>
           <button class="primary" id="chatSend">Send</button>
           <button class="ghost" id="btnAskKeeper" title="Ask Keeper without sending more tokens by default">Ask Keeper</button>
           <button class="ghost" id="btnStopVoice" title="Stop voices & clear queue">Stop Voice</button>

--- a/js/app.js
+++ b/js/app.js
@@ -685,6 +685,34 @@ byId('chatSend').onclick=sendChat;
 byId('chatInput').addEventListener('keydown',e=>{ if(e.key==='Enter') sendChat(); });
 byId('btnStopVoice').onclick=()=> stopVoice(true);
 byId('btnAskKeeper').onclick=()=> askKeeperFromInput();
+// Speech to text
+const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+if(SpeechRecognition){
+  const rec = new SpeechRecognition();
+  rec.lang = 'en-US';
+  rec.interimResults = false;
+  rec.maxAlternatives = 1;
+  rec.onresult = e => {
+    const text = e.results[0][0].transcript;
+    const input = byId('chatInput');
+    input.value = text;
+    sendChat();
+  };
+  rec.onend = ()=> byId('btnSpeech').classList.remove('recording');
+  rec.onerror = ()=> byId('btnSpeech').classList.remove('recording');
+  byId('btnSpeech').onclick = () => {
+    const btn = byId('btnSpeech');
+    if(btn.classList.contains('recording')){
+      rec.stop();
+      btn.classList.remove('recording');
+    }else{
+      btn.classList.add('recording');
+      rec.start();
+    }
+  };
+}else{
+  byId('btnSpeech').style.display='none';
+}
 byId('btnCopyChat').onclick=()=>{ const text=[...chatLog.querySelectorAll('.line')].map(l=>l.innerText.trim()).join('\n'); navigator.clipboard.writeText(text).then(()=>toast('Chat copied')); };
 byId('btnClearChat').onclick=()=>{ if(confirm('Clear chat log?')){ chatLog.innerHTML=''; state.chat=[]; }};
 function askKeeperFromInput(){

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ A modular, client-only tabletop experience inspired by investigative horror RPGs
 - **System Messages:** Generic engine notices (start prompts, dice rolls, invalid moves) appear as ⚙️ lines, separate from the Keeper.
 - **Tactical Board:** Grid, fog of war (reveal/hide/undo), ruler, pings, tokens w/ portraits, active-turn highlight, movement budgets.
 - **Voices:** Queue-based TTS with **Browser voices (free)**, **ElevenLabs** (premium), or **OpenAI TTS**. Per-speaker voice selection, global volume control, and local caching for replays.
+- **Speech to Text:** Click the chat microphone to dictate messages hands-free.
 - **Asset-Full Saves:** Export/import includes scenes, portraits, and handouts as data URLs—no re-generation needed when you reload.
 - **Cost Controls:** Local asset cache, Keeper auto-trigger (switch to manual anytime), quick command picker, offline placeholders if you disable images.
 - **Quality of Life:** Light/dark theme toggle, optional chat timestamps and auto-scroll, copy chat log button, grid toggle and keyboard shortcuts for core panels, in-app help overlay, chat clear button, and resettable settings.

--- a/style.css
+++ b/style.css
@@ -122,6 +122,7 @@
   #chatEntry{display:flex;gap:.5rem;margin-top:.5rem;flex-wrap:wrap}
   #chatEntry input{flex:1;min-width:220px}
   #chatEntry button{white-space:nowrap}
+  #btnSpeech.recording{background:var(--accent);color:#000}
 
   .note{font-size:.85rem;color:#a6b4cc}
 


### PR DESCRIPTION
## Summary
- Add microphone button to chat entry to capture speech and send as chat message
- Highlight speech-to-text capability in documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9baed9bc833186becb84940baa87