### PR TITLE
Fix apostrophe rendering in chat messages

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -653,7 +653,7 @@ function addSay(speaker, text, role='pc', opts={}){
   av.appendChild(img);
   const whoEl=el('div',{class:'who'}, speaker);
   whoEl.style.color = role==='npc' ? '#e3b9ff' : '#b2ffda';
-  const content=el('div',{class:'content'}, escapeHtml(text));
+  const content=el('div',{class:'content', html: escapeHtml(text)});
   const controls=el('div',{class:'controls'});
   if(state.settings.ttsOn){
     controls.appendChild(el('button',{class:'ghost',title:'Replay voice',onclick:()=> speak(stripTags(text), speaker, role)},'▶'));
@@ -691,8 +691,8 @@ function addSystemMessage(text, {html=false, ts=null}={}){
 
 function addWhisper(target, text, ts=null){
   const line=el('div',{class:'line whisper'},[
-    el('div',{class:'who'}, `Whisper to ${escapeHtml(target)}`),
-    el('div',{class:'content'}, escapeHtml(text))
+    el('div',{class:'who', html:`Whisper to ${escapeHtml(target)}`}),
+    el('div',{class:'content', html: escapeHtml(text)})
   ]);
   const time=timestampEl(ts); if(time) line.appendChild(time);
   chatLog.appendChild(line);

--- a/test/app_ui_helpers.js
+++ b/test/app_ui_helpers.js
@@ -17,7 +17,7 @@ function extract(name){
   if(!fn) throw new Error(name + ' not found');
   vm.runInThisContext(fn[0]);
 }
-['el','sanitizeHtml','clamp','makeFog','escapeHtml','stripTags','cellStyle','pxToGrid','deepClone'].forEach(extract);
+['el','sanitizeHtml','clamp','makeFog','escapeHtml','stripTags','cellStyle','pxToGrid','deepClone','addSay','addWhisper'].forEach(extract);
 
 // ---- Tests ----
 
@@ -94,5 +94,22 @@ assert.deepStrictEqual(res,[6,4]);
 global.GRID_WPX = () => 0; global.GRID_HPX = () => 0;
 res = pxToGrid(50,50);
 assert.deepStrictEqual(res,[11,7]);
+
+// addSay and addWhisper should render apostrophes correctly
+global.chatLog = document.createElement('div');
+global.state = { settings:{autoScroll:false, ttsOn:false}, scenes:[{tokens:[]}], sceneIndex:0 };
+global.speakerAvatar = () => '';
+global.currentScene = () => state.scenes[state.sceneIndex];
+global.timestampEl = () => null;
+global.recordEvent = () => {};
+
+addSay('Eve', "I'm fine.");
+let content = chatLog.querySelector('.content');
+assert.strictEqual(content.textContent, "I'm fine.");
+
+chatLog.innerHTML = '';
+addWhisper('Eve', "Don't panic.");
+content = chatLog.querySelector('.content');
+assert.strictEqual(content.textContent, "Don't panic.");
 
 console.log('All UI helper tests passed.');


### PR DESCRIPTION
## Summary
- Render chat and whisper content via escaped HTML to display apostrophes correctly
- Add unit test covering apostrophe handling in chat output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca296cfc883319c78c41966889faf