### PR TITLE
Polish light theme styling for Solo Investigator

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,13 +2,13 @@
     --bg:#0b0f14; --panel:#121821; --panel-2:#0f151e; --ink:#e9eef7; --muted:#a7b0c0;
     --brand:#7aa2ff; --accent:#86f0d1; --danger:#ff6b6b; --warn:#ffc04d; --ok:#59db7d;
     --grid:#1c2230; --grid-2:#151a25; --glow:0 0 20px rgba(122,162,255,.25);
-    --pc:#2e6a53; --npc:#5a365a; --keeper:#1f2a44;
+    --pc:#2e6a53; --npc:#5a365a; --keeper:#1f2a44; --edge:#1a2130;
   }
   body.light{
-    --bg:#f0f2f5; --panel:#ffffff; --panel-2:#f5f5f5; --ink:#1a1a1a; --muted:#555;
-    --brand:#0050d0; --accent:#0a8e6a; --danger:#c0392b; --warn:#b8860b; --ok:#2e8b57;
-    --grid:#d0d7e5; --grid-2:#c2c9d6; --glow:0 0 20px rgba(0,80,208,.25);
-    --pc:#8fbc8f; --npc:#d8bfd8; --keeper:#b0c4de;
+    --bg:#f7f9fc; --panel:#ffffff; --panel-2:#f0f2f5; --ink:#1a1a1a; --muted:#555;
+    --brand:#3366ff; --accent:#00b894; --danger:#e74c3c; --warn:#e67e22; --ok:#27ae60;
+    --grid:#d0d7e5; --grid-2:#c2c9d6; --glow:0 0 20px rgba(51,102,255,.25);
+    --pc:#a4d4c2; --npc:#e0c4e0; --keeper:#c9d6f7; --edge:#bcc5d6;
   }
   *{box-sizing:border-box}
   html,body{height:100%}
@@ -23,14 +23,14 @@
     height:100vh;
   }
   body.light{
-    background:radial-gradient(1200px 700px at 70% -10%,#eaeff8 0,#dfe4ee 55%,#cfd4e3 100%);
+    background:radial-gradient(1200px 700px at 70% -10%,#ffffff 0,#f0f3f9 55%,#e0e6f1 100%);
   }
   body.light button,body.light select,body.light input,body.light textarea{
-    border-color:#bcc5d6;
+    border-color:var(--edge);
   }
   a{color:var(--brand)}
   button,select,input,textarea{
-    background:var(--panel); color:var(--ink); border:1px solid #212a3b; border-radius:8px; padding:.6rem .75rem
+    background:var(--panel); color:var(--ink); border:1px solid var(--edge); border-radius:8px; padding:.6rem .75rem
   }
   button{cursor:pointer}
   button.primary{background:linear-gradient(180deg,#1f2a44,#152037);border-color:#31405c;box-shadow:var(--glow)}
@@ -47,17 +47,20 @@
 
   header.appbar{
     position:sticky;top:0;z-index:50;background:rgba(10,14,20,.9);backdrop-filter:blur(6px);
-    border-bottom:1px solid #1b2332;display:flex;align-items:center;gap:1rem;padding:.75rem 1rem
+    border-bottom:1px solid var(--edge);display:flex;align-items:center;gap:1rem;padding:.75rem 1rem
   }
   header.appbar h1{margin:0;font-size:1rem;letter-spacing:.12rem;text-transform:uppercase;color:#bcd1ff}
+  body.light header.appbar{background:rgba(255,255,255,.9)}
+  body.light header.appbar h1{color:#334}
   header.appbar nav{display:flex;gap:.5rem;flex-wrap:wrap}
   header.appbar nav button{padding:.45rem .6rem}
 
   .container{display:grid;grid-template-columns:320px 1fr 360px;gap:1rem;padding:1rem;align-items:stretch;flex:1;min-height:0}
   @media (max-width: 1100px){ .container{grid-template-columns:1fr} }
 
-  .panel{background:linear-gradient(180deg, var(--panel), var(--panel-2));border:1px solid #1a2130;border-radius:12px;padding:1rem;box-shadow:var(--glow)}
+  .panel{background:linear-gradient(180deg, var(--panel), var(--panel-2));border:1px solid var(--edge);border-radius:12px;padding:1rem;box-shadow:var(--glow)}
   .panel h2{margin:.25rem 0 1rem 0;font-size:1rem;color:#c9d6f7}
+  body.light .panel h2{color:#2a3450}
   .leftcol,.rightcol{display:flex;flex-direction:column;gap:1rem;min-height:0}
   .leftcol > .panel{flex:1;display:flex;flex-direction:column;min-height:0}
 
@@ -103,13 +106,15 @@
     flex:1; /* fill remaining space */
     overflow-y:auto;
     min-height:0;
-    background:#0c121d;border:1px solid #1a2130;border-radius:8px;padding:.75rem;scroll-behavior:smooth;
+    background:var(--panel);border:1px solid var(--edge);border-radius:8px;padding:.75rem;scroll-behavior:smooth;
   }
   #chatLog .line{display:flex;align-items:flex-start;gap:.6rem;margin:.45rem 0}
-  #chatLog .line.action{font-style:italic;color:var(--muted);background:#0c121d;border-radius:4px;padding:.2rem .4rem}
+  #chatLog .line.action{font-style:italic;color:var(--muted);background:var(--panel-2);border-radius:4px;padding:.2rem .4rem}
   #chatLog .line.system{color:var(--muted)}
   #chatLog .line.whisper{font-style:italic;opacity:.85;background:#221a0f;border-radius:4px;padding:.2rem .4rem}
   #chatLog .line.whisper .who{color:#ffd29d}
+  body.light #chatLog .line.whisper{background:#fff7e6}
+  body.light #chatLog .line.whisper .who{color:#b8860b}
   #chatLog .who{opacity:.85;font-weight:600}
   #chatLog .content{flex:1}
   #chatLog .controls{display:flex;gap:.25rem}
@@ -131,7 +136,8 @@
   .modal.show{display:flex}
   .modal .scrim{position:absolute;inset:0;background:rgba(6,8,12,.75);backdrop-filter:blur(6px)}
   .modal .sheet{position:relative;max-width:1100px;width:min(1100px,96vw);max-height:90vh;overflow:auto;border-radius:14px;
-    background:linear-gradient(180deg,#0d1220,#0a0f19);border:1px solid #1a2231;padding:1rem;box-shadow:0 10px 40px rgba(0,0,0,.5)}
+    background:linear-gradient(180deg,var(--panel),var(--panel-2));border:1px solid var(--edge);padding:1rem;box-shadow:0 10px 40px rgba(0,0,0,.5)}
+  body.light .modal .scrim{background:rgba(0,0,0,.35)}
   .grid2{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
   .grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:.75rem}
   .grid4{display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:.75rem}
@@ -139,16 +145,17 @@
   .small{font-size:.85rem;color:#9fb0c8}
   .hr{height:1px;background:#1b2333;margin:.75rem 0}
   .right{justify-content:flex-end}
-  .card{border:1px solid #233048;background:#0e1524;border-radius:10px;padding:.6rem}
+  .card{border:1px solid var(--edge);background:var(--panel);border-radius:10px;padding:.6rem}
   .card h3{margin:.2rem 0 .4rem 0;font-size:1rem;color:#d7e4ff}
+  body.light .card h3{color:#2a3450}
   .meSel{outline:2px solid #59db7d; box-shadow:0 0 0 4px rgba(89,219,125,.18)}
   .compSel{outline:2px solid #7aa2ff; box-shadow:0 0 0 4px rgba(122,162,255,.18)}
 
   /* Handouts */
-  #handoutsList img{max-width:100%;height:auto;border:1px solid #1a2231;border-radius:8px;display:block;margin:.35rem 0}
-  #handoutsList .ho{border:1px solid #223049;border-radius:10px;padding:.6rem;margin:.5rem 0;background:#0f1525}
+  #handoutsList img{max-width:100%;height:auto;border:1px solid var(--edge);border-radius:8px;display:block;margin:.35rem 0}
+  #handoutsList .ho{border:1px solid var(--edge);border-radius:10px;padding:.6rem;margin:.5rem 0;background:var(--panel)}
   #handoutsList .ho h4{margin:.25rem 0 .3rem 0}
-  #clueList .clue{border:1px solid #223049;border-radius:10px;padding:.6rem;margin:.5rem 0;background:#0f1525}
+  #clueList .clue{border:1px solid var(--edge);border-radius:10px;padding:.6rem;margin:.5rem 0;background:var(--panel)}
   #clueList .clue h4{margin:.25rem 0 .3rem 0}
   .chat-handout img{max-width:100%;height:auto;border:1px solid #1a2231;border-radius:8px;margin-top:.35rem}
 
@@ -170,7 +177,7 @@
 
   /* Save slots */
   .slots{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem}
-  .slots .slot{display:flex;flex-direction:column;gap:.5rem;border:1px dashed #2b3650;border-radius:10px;padding:.6rem;background:#0c121c}
+  .slots .slot{display:flex;flex-direction:column;gap:.5rem;border:1px dashed var(--edge);border-radius:10px;padding:.6rem;background:var(--panel)}
   .slots .slot.used{border-style:solid}
   .slots .meta{display:flex;flex-direction:column;gap:.15rem}
   .slots .meta .slotname{font-size:.75rem;color:var(--muted)}
@@ -181,7 +188,7 @@
   .slots .ts{font-size:.75rem;color:#8ea0bf}
 
   /* Toast */
-  #toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#0e1524;border:1px solid #223049;border-radius:10px;padding:.5rem .8rem;color:#cfe1ff;opacity:0;pointer-events:none;transition:opacity .25s;z-index:120}
+  #toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:var(--panel);border:1px solid var(--edge);border-radius:10px;padding:.5rem .8rem;color:#cfe1ff;opacity:0;pointer-events:none;transition:opacity .25s;z-index:120}
   #toast.show{opacity:1}
 
   /* Initiative Thinking Indicator */


### PR DESCRIPTION
## Summary
- Refine light theme palette and add reusable `--edge` border variable
- Apply theme-aware colors to panels, chat log, cards, and modals for a cohesive light mode
- Update toast and save slot styles to respect theme variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689caf7314dc83318a5ddec61f637f26