### PR TITLE
Persist API keys in dedicated storage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ readme.md    - documentation
 - **Keeper Style/Max Tokens:** Control verbosity and token budget to reduce spend.
 - **Rules Pack:** Your own notes/house-rules (do not paste copyrighted text).
 
-> Settings are stored in `localStorage` under `si_settings_v8`.
+> Settings are stored in `localStorage` under `si_settings_v8`. API keys are kept separately under `si_key_openai` and `si_key_eleven`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Save OpenAI and ElevenLabs API keys in their own localStorage entries
- Update settings load/save/reset flows to use new key persistence
- Document separate key storage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccfcc05288331856491d6aa435a65