### PR TITLE
Persist voice settings on load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1294,6 +1294,8 @@ function captureState(){
 }
 function applyState(data){
   Object.assign(state.settings, data.settings||{});
+  // Persist any settings from the loaded state so voice and other prefs survive reloads
+  saveSettings(false);
   state.sceneIndex=data.sceneIndex||0;
   state.scenes=data.scenes||[newScene('Recovered')];
   state.campaign=data.campaign||null;


### PR DESCRIPTION
## Summary
- Persist loaded settings to localStorage before applying them
- Ensure chosen TTS voice and other preferences survive save/load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d235861fc8331a5ddc66f77e4a23d