### PR TITLE
Fix multiple engine and helper bugs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -245,7 +245,8 @@ function stripTags(s){
 }
 function sanitizeHtml(html){
   const t=document.createElement('template');
-  t.innerHTML=html||'';
+  // Preserve falsy-but-valid values like 0 instead of defaulting to empty string
+  t.innerHTML=String(html ?? '');
   t.content.querySelectorAll('script,style,iframe,object,link,meta,base,form,input,button,textarea,select').forEach(el=>el.remove());
   t.content.querySelectorAll('*').forEach(el=>{
     [...el.attributes].forEach(a=>{
@@ -718,7 +719,8 @@ function addSay(speaker, text, role='pc', opts={}){
   if(state.settings.autoScroll) chatLog.scrollTop=chatLog.scrollHeight;
   const token=currentScene().tokens.find(t => t.name===speaker);
   if(token) token.lastSaid = stripTags(text);
-  recordEvent(`${speaker}: ${text}`);
+  // Strip any HTML before logging the event to avoid leaking markup
+  recordEvent(`${speaker}: ${stripTags(text)}`);
 }
 
 function addActionLine(text, ts=null){
@@ -748,7 +750,8 @@ function addWhisper(target, text, ts=null){
   const time=timestampEl(ts); if(time) line.appendChild(time);
   chatLog.appendChild(line);
   if(state.settings.autoScroll) chatLog.scrollTop=chatLog.scrollHeight;
-  recordEvent(`Whisper to ${target}: ${text}`);
+  // Sanitize text before recording the whisper event
+  recordEvent(`Whisper to ${target}: ${stripTags(text)}`);
 }
 function speakerAvatar(name){
   const key=(name||'').trim().toLowerCase();

--- a/js/director.js
+++ b/js/director.js
@@ -56,7 +56,8 @@ class NarrationDirector {
         const convo = this.getConversation(action.target);
         this.remember('dialogue', action.text||'', [action.target].filter(Boolean), actor);
         this.advanceConversation(action.target, actor, action);
-        if(convo.needsRoll){
+        // Only check for rolls if a conversation context exists
+        if(convo && convo.needsRoll){
           res.rollRequests=[{character:actor.name, skill:convo.pendingSkill||'Charm', mod:action.mod||0}];
           convo.needsRoll=false;
         }
@@ -87,9 +88,12 @@ class NarrationDirector {
   }
   findToken(name){
     if(!this.state) return null;
-    let sc;
-    if(typeof currentScene==='function') sc=currentScene();
-    else if(this.state.scenes) sc=this.state.scenes[this.state.sceneIndex||0];
+    // Prefer the global currentScene() helper when available for accurate clamping
+    let sc = typeof currentScene==='function' ? currentScene() : null;
+    if(!sc && Array.isArray(this.state.scenes)){
+      const i = Math.min(Math.max(this.state.sceneIndex || 0, 0), this.state.scenes.length-1);
+      sc = this.state.scenes[i];
+    }
     return sc?.tokens?.find(t=>t.name===name);
   }
   getConversation(targetName){

--- a/test/app_ui_helpers.js
+++ b/test/app_ui_helpers.js
@@ -51,6 +51,9 @@ assert(!clean.includes('link'));
 assert(!clean.includes('meta'));
 assert(!clean.includes('javascript:'));
 
+// sanitizeHtml should preserve numeric input like 0
+assert.strictEqual(sanitizeHtml(0), '0');
+
 // clamp should handle swapped bounds and invalid inputs
 assert.strictEqual(clamp('5','10','1'),5); // swaps
 assert.strictEqual(clamp('bad',0,2),0); // invalid value
@@ -113,6 +116,17 @@ chatLog.innerHTML = '';
 addWhisper('Eve', "Don't panic.");
 content = chatLog.querySelector('.content');
 assert.strictEqual(content.textContent, "Don't panic.");
+
+// addSay/addWhisper should strip tags before recording events
+let logged = '';
+global.recordEvent = msg => { logged = msg; };
+chatLog.innerHTML = '';
+addSay('Eve', '<b>hi</b>');
+assert.strictEqual(logged, 'Eve: hi');
+chatLog.innerHTML = '';
+logged = '';
+addWhisper('Eve', '<i>secret</i>');
+assert.strictEqual(logged, 'Whisper to Eve: secret');
 
 // el should accept NodeList children
 document.body.innerHTML = '<span>A</span><span>B</span>';

--- a/test/director.js
+++ b/test/director.js
@@ -27,4 +27,14 @@ director.remember('action', {type:'use', item:'Key'}, ['use','Key'], actor);
 assert.strictEqual(director.memory.length, memBefore + 1);
 assert.ok(director.getMemories('Key').length >= 1);
 
+// findToken should handle out-of-range scene indices
+state.sceneIndex = -5;
+assert.strictEqual(director.findToken('Bob').name, 'Bob');
+state.sceneIndex = 10;
+assert.strictEqual(director.findToken('Bob').name, 'Bob');
+
+// talking without a target shouldn't throw
+const res2 = director.handleAction(actor, {type:'talk', text:'Hello there'});
+assert.strictEqual(res2.narration, 'Hello there');
+
 console.log('director tests passed');


### PR DESCRIPTION
## Summary
- Sanitize HTML inputs that are numeric or falsy values
- Strip tags when recording chat lines and whispers
- Guard conversation roll checks and clamp scene lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e2db5c7048331a8f293160dca951c