### PR TITLE
Fix multiple small bugs in helpers and director logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -239,15 +239,15 @@ function escapeHtml(s){
 }
 function stripTags(s){
   const d=document.createElement('div');
-  // Convert to string so numeric values aren't dropped
-  d.innerHTML=String(s ?? '');
+  // Sanitize first so script/style content is dropped entirely
+  d.innerHTML=sanitizeHtml(String(s ?? ''));
   return d.textContent||d.innerText||'';
 }
 function sanitizeHtml(html){
   const t=document.createElement('template');
   // Preserve falsy-but-valid values like 0 instead of defaulting to empty string
   t.innerHTML=String(html ?? '');
-  t.content.querySelectorAll('script,style,iframe,object,link,meta,base,form,input,button,textarea,select').forEach(el=>el.remove());
+  t.content.querySelectorAll('script,style,iframe,object,link,meta,base,form,input,button,textarea,select,noscript,video,audio,embed').forEach(el=>el.remove());
   t.content.querySelectorAll('*').forEach(el=>{
     [...el.attributes].forEach(a=>{
       if(/^on/i.test(a.name) || /javascript:/i.test(a.value)) el.removeAttribute(a.name);

--- a/js/director.js
+++ b/js/director.js
@@ -84,7 +84,9 @@ class NarrationDirector {
   }
   hasItem(actor, item){
     const inv = actor.sheet?.inventory || [];
-    return inv.some(i=>i.name===item && (i.qty||0)>0);
+    if(typeof item!== 'string') return false;
+    const name = item.toLowerCase();
+    return inv.some(i=> (i.name||'').toLowerCase()===name && (i.qty||0)>0);
   }
   findToken(name){
     if(!this.state) return null;
@@ -94,10 +96,10 @@ class NarrationDirector {
       const i = Math.min(Math.max(this.state.sceneIndex || 0, 0), this.state.scenes.length-1);
       sc = this.state.scenes[i];
     }
-    return sc?.tokens?.find(t=>t.name===name);
+    return sc?.tokens?.find(t=>t.name===name || t.id===name) || null;
   }
   getConversation(targetName){
-    if(!targetName) return null;
+    if(typeof targetName !== 'string' || !targetName) return null;
     this.conversations[targetName]=this.conversations[targetName]||{stage:'start',history:[],pendingSkill:null,needsRoll:false};
     return this.conversations[targetName];
   }

--- a/test/app_ui_helpers.js
+++ b/test/app_ui_helpers.js
@@ -51,6 +51,14 @@ assert(!clean.includes('link'));
 assert(!clean.includes('meta'));
 assert(!clean.includes('javascript:'));
 
+// sanitizeHtml should strip additional media and noscript tags
+const dirty3 = '<noscript>bad</noscript><video></video><audio></audio><embed></embed>';
+const clean3 = sanitizeHtml(dirty3);
+assert(!clean3.includes('noscript'));
+assert(!clean3.includes('video'));
+assert(!clean3.includes('audio'));
+assert(!clean3.includes('embed'));
+
 // sanitizeHtml should preserve numeric input like 0
 assert.strictEqual(sanitizeHtml(0), '0');
 
@@ -63,6 +71,8 @@ assert.strictEqual(clamp(5,0,Infinity),5); // Infinity bound
 // escapeHtml and stripTags should preserve numbers
 assert.strictEqual(escapeHtml(0), '0');
 assert.strictEqual(stripTags(0), '0');
+// stripTags should drop script/style content entirely
+assert.strictEqual(stripTags('<script>alert(1)</script>hello'), 'hello');
 assert.strictEqual(escapeHtml("<>&\"'"), '&lt;&gt;&amp;&quot;&#39;');
 
 // deepClone should copy objects deeply and preserve Dates even without structuredClone

--- a/test/director.js
+++ b/test/director.js
@@ -21,6 +21,10 @@ assert.strictEqual(director.validateAction(actor, {type:'talk', target:'Ghost'})
 const res = director.handleAction(actor, {type:'talk', target:'Bob', intent:'persuade'});
 assert.ok(res.rollRequests && res.rollRequests[0].skill === 'Charm');
 
+// hasItem should be case-insensitive and ignore non-strings
+assert.strictEqual(director.hasItem(actor, 'key'), true);
+assert.strictEqual(director.hasItem(actor, 123), false);
+
 // memory tagging
 const memBefore = director.memory.length;
 director.remember('action', {type:'use', item:'Key'}, ['use','Key'], actor);
@@ -32,6 +36,12 @@ state.sceneIndex = -5;
 assert.strictEqual(director.findToken('Bob').name, 'Bob');
 state.sceneIndex = 10;
 assert.strictEqual(director.findToken('Bob').name, 'Bob');
+// findToken should also locate by id
+assert.strictEqual(director.findToken('npc1').name, 'Bob');
+
+// getConversation should reject non-string targets
+assert.strictEqual(director.getConversation(null), null);
+assert.strictEqual(director.getConversation({}), null);
 
 // talking without a target shouldn't throw
 const res2 = director.handleAction(actor, {type:'talk', text:'Hello there'});


### PR DESCRIPTION
## Summary
- Sanitize HTML more thoroughly and remove script/style content when stripping tags
- Improve item lookups and token search in the narration director
- Ensure conversations are keyed only by valid string targets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e39faff088331b1c582eb5c1bd270