### PR TITLE
Reset state for new story and auto advance after build

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1678,7 +1678,28 @@ async function hashKey(s){ const buf=new TextEncoder().encode(s); const hash=awa
 const wizard={step:0, arc:null, youIndex:null, companions:[], rolls:{}, variety:{ era:'1920s', locale:'Inland city', theme:'Investigative', avoidCoast:true, seed:Math.floor(Math.random()*1e9)}};
 byId('btnWizardNext').onclick=()=> wizardNext();
 byId('btnWizardBack').onclick=()=> wizardBack();
-function startWizard(force=false){ if(!force && localStorage.getItem(LS_WIZARD)) return; wizard.step=0; wizard.arc=null; wizard.youIndex=null; wizard.companions=[]; wizard.rolls={}; renderWizard(); show('#modalWizard'); }
+function resetForNewGame(){
+  const settings = JSON.parse(JSON.stringify(state.settings));
+  const voices = state.browserVoices;
+  Object.assign(state, createState());
+  state.settings = settings;
+  state.browserVoices = voices;
+  if(typeof director !== 'undefined'){
+    director.memory = [];
+    director.conversations = {};
+  }
+}
+function startWizard(force=false){
+  if(!force && localStorage.getItem(LS_WIZARD)) return;
+  resetForNewGame();
+  renderAll();
+  renderClues();
+  renderHandouts();
+  restoreChat(state.chat);
+  wizard.step=0; wizard.arc=null; wizard.youIndex=null; wizard.companions=[]; wizard.rolls={};
+  renderWizard();
+  show('#modalWizard');
+}
 function setStepPills(){ for(let i=0;i<5;i++){ const elB=byId('wStep'+i+'B'); if(elB) elB.classList.toggle('active', i===wizard.step); } }
 function renderWizard(){
   setStepPills(); const body=byId('wizardBody'); body.innerHTML='';
@@ -1778,7 +1799,9 @@ function renderWizard(){
       el('div',{class:'card'},[
         el('h3',{},'4) Auto‑build your game (with progress)'),
         el('div',{class:'small'},'Creates scenes per act, backgrounds (or placeholders), spawns your chosen party + NPCs, portraits, handouts, and an NPC portrait catalog.'),
-        el('div',{class:'row'},[ el('button',{class:'primary',onclick:()=> wizardAutoBuildEverything()},'Build Everything Now') ]),
+        el('div',{class:'row'},[
+          el('button',{class:'primary',onclick:async ()=>{ await wizardAutoBuildEverything(); wizardNext(); }},'Build Everything Now')
+        ]),
         el('div',{id:'buildStatus',class:'note',style:'margin-top:.5rem'}, 'Not built yet.')
       ]),
       el('div',{class:'card'},[
@@ -2288,4 +2311,4 @@ async function greetAndStart(){
 
 /* Boot */
 loadSettings(); initialSeed(); renderAll(); renderInitButtons(); if(!localStorage.getItem(LS_WIZARD)) startWizard(false);
-if(typeof module!== 'undefined') module.exports={createState};
+if(typeof module!== 'undefined') module.exports={createState, resetForNewGame};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modular, client-only tabletop experience inspired by investigative horror RPGs. It teaches the basics through a guided wizard, runs entirely in your browser (or GitHub Pages), and can optionally use OpenAI for story/asset generation and ElevenLabs, OpenAI TTS, or your browser for voices.",
   "main": "index.js",
   "scripts": {
-    "test": "node test/app_ui_helpers.js && node test/scene_manager.js && node test/director.js && node --check js/director.js && node --check js/app.js && node --check js/keeper.js && node --check js/sceneManager.js"
+    "test": "node test/app_ui_helpers.js && node test/scene_manager.js && node test/director.js && node test/reset_game.js && node --check js/director.js && node --check js/app.js && node --check js/keeper.js && node --check js/sceneManager.js"
   },
   "keywords": [],
   "author": "",

--- a/test/reset_game.js
+++ b/test/reset_game.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://example.org/' });
+global.window = dom.window;
+global.document = dom.window.document;
+global.localStorage = dom.window.localStorage;
+
+const code = fs.readFileSync(path.join(__dirname, '../js/app.js'), 'utf8');
+function extract(name){
+  const fn = code.match(new RegExp(`function\\s+${name}\\([^]*?\n}`, 'm'));
+  if(!fn) throw new Error(name + ' not found');
+  vm.runInThisContext(fn[0]);
+}
+extract('makeFog');
+extract('newScene');
+extract('createState');
+extract('resetForNewGame');
+
+global.GRID_W = 12;
+global.GRID_H = 8;
+global.state = createState();
+state.memory.summary = 'old';
+state.chat.push({text:'hi'});
+global.director = { memory:[{x:1}], conversations:{a:1} };
+
+resetForNewGame();
+
+assert.deepStrictEqual(state.memory, {summary:'', scenes:{}});
+assert.deepStrictEqual(state.chat, []);
+assert.strictEqual(director.memory.length, 0);
+assert.deepStrictEqual(director.conversations, {});
+
+console.log('reset game tests passed');


### PR DESCRIPTION
## Summary
- Add `resetForNewGame` to rebuild state and clear director/conversation memory when starting the wizard
- Auto-advance the wizard after "Build Everything Now" completes
- Test coverage for resetting game state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc9cca638833197c12306b83dccdf